### PR TITLE
Use a repository approach

### DIFF
--- a/lib/controllers/players_controller.rb
+++ b/lib/controllers/players_controller.rb
@@ -1,8 +1,15 @@
 module PokerArena
   class PlayersController < Sinatra::Base
+    def initialize(app, options)
+      super(app)
+      @players_repository = options.fetch(:players_repository)
+    end
+
     get '/api/players/generate' do
-      token = Player.generate
-      json(player: token)
+      player = Player.new
+      @players_repository.persist(player)
+
+      json(player: player.token)
     end
   end
 end

--- a/lib/controllers/tables_controller.rb
+++ b/lib/controllers/tables_controller.rb
@@ -1,13 +1,27 @@
 module PokerArena
   class TablesController < Sinatra::Base
+    def initialize(app, options)
+      super(app)
+      @tables_repository = options.fetch(:tables_repository)
+    end
+
     get '/api/tables/generate' do
-      name = Table.generate
-      json(table: name)
+      table = Table.new(tables_repository: @tables_repository)
+      @tables_repository.persist(table)
+
+      json(table: table.name)
     end
 
     get '/api/tables' do
-      tables = Table.informations
-      json(tables: tables)
+      informations = @tables_repository.all.map do |table|
+        {
+          name: table.name,
+          max_players: table.max_players,
+          available_seats: table.available_seats
+        }
+      end
+
+      json(tables: informations)
     end
   end
 end

--- a/lib/models/player.rb
+++ b/lib/models/player.rb
@@ -2,27 +2,9 @@ module PokerArena
   class Player
     MAX_CARDS = 2
 
-    class << self
-      def generate
-        new.token
-      end
-
-      def all
-        ObjectSpace.each_object(self).to_a
-      end
-
-      def find(token)
-        all.find { |player| player.token == token }
-      end
-
-      def valid_token?(token)
-        find(token) ? true : false
-      end
-    end
-
     attr_reader :token, :cards
+
     def initialize
-      @token = SecureRandom.hex(5)
       @cards = []
     end
 

--- a/lib/models/table.rb
+++ b/lib/models/table.rb
@@ -15,33 +15,24 @@ module PokerArena
       ].freeze
 
     class << self
-      def generate
-        new.name
-      end
-
-      def informations
-        all.map do |table|
-          {
-            name: table.name,
-            max_players: MAX_PLAYERS,
-            available_seats: MAX_PLAYERS - table.seats.count
-          }
-        end
-      end
-
-      def all
-        ObjectSpace.each_object(self).to_a
-      end
-
-      def available_names
-        NAMES - all.map(&:name)
+      def available_names(tables_repository)
+        NAMES - tables_repository.all.map(&:name)
       end
     end
 
     attr_reader :name, :seats
-    def initialize
-      @name = self.class.available_names.sample
+
+    def initialize(tables_repository:)
+      @name = self.class.available_names(tables_repository).sample
       @seats = []
+    end
+
+    def max_players
+      MAX_PLAYERS
+    end
+
+    def available_seats
+      MAX_PLAYERS - seats.count
     end
 
     def seat_in(player)

--- a/lib/models/table.rb
+++ b/lib/models/table.rb
@@ -23,8 +23,12 @@ module PokerArena
     attr_reader :name, :seats
 
     def initialize(tables_repository:)
-      @name = self.class.available_names(tables_repository).sample
       @seats = []
+      @name = self.class.available_names(tables_repository).sample
+
+      if @name.nil?
+        raise ArgumentError, 'No more available table names in that repository'
+      end
     end
 
     def max_players

--- a/lib/poker_arena.rb
+++ b/lib/poker_arena.rb
@@ -2,15 +2,17 @@ require 'bcrypt'
 require 'pry'
 require 'sinatra'
 require 'sinatra/json'
-require 'sinatra/namespace'
 
 Dir['./lib/models/*.rb'].each { |file| require file }
+Dir['./lib/repositories/*.rb'].each { |file| require file }
 Dir['./lib/controllers/*_controller.rb'].each { |file| require file }
 
 module PokerArena
   class Launcher < Sinatra::Base
-    register Sinatra::Namespace
-    use PlayersController
-    use TablesController
+    players_repository = PlayersRepository.new
+    tables_repository = TablesRepository.new
+
+    use PlayersController, players_repository: players_repository
+    use TablesController, tables_repository: tables_repository
   end
 end

--- a/lib/repositories/players_repository.rb
+++ b/lib/repositories/players_repository.rb
@@ -1,0 +1,45 @@
+module PokerArena
+  class PlayersRepository
+    def initialize
+      @players = {}
+    end
+
+    def all
+      @players.values
+    end
+
+    def find(token)
+      @players.fetch(token)
+    end
+
+    def persist(player)
+      if @players.key?(player.token)
+        if find(player.token) != player
+          raise ArgumentError, "Another player with token '#{player.token}' exists."
+        else
+          return true
+        end
+      end
+
+      token = unused_token
+      player.instance_variable_set(:@token, token)
+      @players[token] = player
+
+      true
+    end
+
+    private
+
+    def unused_token
+      iteration = 0
+
+      loop do
+        token = SecureRandom.hex(5)
+        return token unless @players.key?(token)
+
+        iteration += 1
+        raise "Can't find a new and unused token" if iteration > 5
+      end
+    end
+  end
+end

--- a/lib/repositories/players_repository.rb
+++ b/lib/repositories/players_repository.rb
@@ -1,7 +1,10 @@
 module PokerArena
   class PlayersRepository
-    def initialize
+    DEFAULT_TOKEN_SIZE = 5
+
+    def initialize(token_size: DEFAULT_TOKEN_SIZE)
       @players = {}
+      @token_size = token_size
     end
 
     def all
@@ -34,7 +37,7 @@ module PokerArena
       iteration = 0
 
       loop do
-        token = SecureRandom.hex(5)
+        token = SecureRandom.hex(@token_size)
         return token unless @players.key?(token)
 
         iteration += 1

--- a/lib/repositories/tables_repository.rb
+++ b/lib/repositories/tables_repository.rb
@@ -1,0 +1,29 @@
+module PokerArena
+  class TablesRepository
+    def initialize
+      @tables = {}
+    end
+
+    def all
+      @tables.values
+    end
+
+    def find(name)
+      @tables.fetch(name)
+    end
+
+    def persist(table)
+      if @tables.key?(table.name)
+        if find(table.name) != table
+          raise ArgumentError, "Another table named '#{table.name}' exists."
+        else
+          return true
+        end
+      end
+
+      @tables[table.name] = table
+
+      true
+    end
+  end
+end

--- a/spec/models/players_spec.rb
+++ b/spec/models/players_spec.rb
@@ -1,28 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe PokerArena::Player do
-  describe '.generate' do
-    it 'return 10 characters token' do
-      expect(described_class.generate.size).to eql(10)
-    end
-  end
-
-  describe '.valid_token' do
-    it 'return true for created token' do
-      token = PokerArena::Player.generate
-      token_is_valid = PokerArena::Player.valid_token?(token)
-
-      expect(token_is_valid).to eql(true)
-    end
-
-    it 'return false for random token' do
-      token = SecureRandom.hex(5)
-      token_is_invalid = PokerArena::Player.valid_token?(token)
-
-      expect(token_is_invalid).to eql(false)
-    end
-  end
-
   describe '#receive_card' do
     it 'raise an error for full of card player' do
       player = described_class.new

--- a/spec/models/tables_spec.rb
+++ b/spec/models/tables_spec.rb
@@ -1,39 +1,52 @@
 require 'spec_helper'
 
 RSpec.describe PokerArena::Table do
+  let(:repo) { PokerArena::TablesRepository.new }
+  let(:table) { described_class.new(tables_repository: repo) }
+
+  describe '#initialize' do
+    it "selects a name that isn't already in the repository" do
+      existing_table_names = repo.all.map(&:name)
+      expect(existing_table_names).not_to include(table.name)
+    end
+
+    context 'when all names are taken in the repository' do
+      it 'raises an error' do
+        expect {
+          loop do
+            table = described_class.new(tables_repository: repo)
+            repo.persist(table)
+          end
+        }.to raise_error(/No more available table names in that repository/)
+      end
+    end
+  end
+
   describe '#seat_in' do
     it 'add players to the table' do
-      hero = PokerArena::Player.new
-      vilain = PokerArena::Player.new
-      table = described_class.new
-      table.seat_in(hero)
-      table.seat_in(vilain)
-
-      expect(table.seats.count).to eql(2)
+      expect {
+        table.seat_in(PokerArena::Player.new)
+        table.seat_in(PokerArena::Player.new)
+      }.to change {
+        table.seats.count
+      }.from(0).to(2)
     end
 
     it 'restrict the number of players per table' do
-      hero = PokerArena::Player.new
-      vilain = PokerArena::Player.new
-      hacker = PokerArena::Player.new
+      table.seat_in(PokerArena::Player.new)
+      table.seat_in(PokerArena::Player.new)
 
-      table = described_class.new
-
-      table.seat_in(hero)
-      table.seat_in(vilain)
-
-      expect { table.seat_in(hacker) }.to raise_error(RangeError)
+      expect { table.seat_in(PokerArena::Player.new) }
+        .to raise_error(RangeError)
     end
 
     it 'restrict to uniq player' do
-      table = described_class.new
-
       expect { table.seat_in('John Snow') }.to raise_error(TypeError)
     end
 
     it 'restrict to uniq player' do
       player = PokerArena::Player.new
-      table = described_class.new
+
       table.seat_in(player)
 
       expect { table.seat_in(player) }.to raise_error(IndexError)

--- a/spec/repositories/players_spec.rb
+++ b/spec/repositories/players_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe PokerArena::PlayersRepository do
+  describe '#persist' do
+    let(:repo) { described_class.new(token_size: 1) }
+    let(:unpersisted_player) { PokerArena::Player.new }
+
+    it 'sets the token on the given player' do
+      expect { repo.persist(unpersisted_player) }
+        .to change { unpersisted_player.token }
+        .from(nil)
+        .to(be_a(String))
+    end
+
+    it 'adds the player into the repository' do
+      expect { repo.persist(unpersisted_player) }
+        .to change { repo.all }
+        .from(an_array_excluding(unpersisted_player))
+        .to(include(unpersisted_player))
+    end
+
+    context 'when the player has already been persisted' do
+      let!(:already_persisted_player) do
+        PokerArena::Player.new.tap { |player| repo.persist(player) }
+      end
+
+      it "maintains the player's token" do
+        expect { repo.persist(already_persisted_player) }
+          .not_to change { already_persisted_player.token }
+      end
+
+      it 'keeps only one copy of the player in the repository' do
+        expect { repo.persist(already_persisted_player) }
+          .not_to change { repo.all.size }
+      end
+    end
+
+    context "when there isn't any more unique token" do
+      it 'raise an error' do
+        expect { loop { repo.persist(PokerArena::Player.new) } }
+          .to raise_error(/Can't find a new and unused token/)
+      end
+    end
+  end
+end

--- a/spec/repositories/tables_spec.rb
+++ b/spec/repositories/tables_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe PokerArena::TablesRepository do
+  describe '#persist' do
+    let(:repo) { described_class.new }
+    let(:unpersisted_table) { PokerArena::Table.new(tables_repository: repo) }
+
+    it 'adds the table into the repository' do
+      expect { repo.persist(unpersisted_table) }
+        .to change { repo.all }
+        .from(an_array_excluding(unpersisted_table))
+        .to(include(unpersisted_table))
+    end
+
+    context 'when the table has already been persisted' do
+      let!(:already_persisted_table) do
+        PokerArena::Table.new(tables_repository: repo).tap do |table|
+          repo.persist(table)
+        end
+      end
+
+      it 'keeps only one copy of the table in the repository' do
+        expect { repo.persist(already_persisted_table) }
+          .not_to change { repo.all.size }
+      end
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,1 @@
+RSpec::Matchers.define_negated_matcher :an_array_excluding, :include


### PR DESCRIPTION
Toujours in-memory mais en séparant la couche de persistance le plus possible de la couche métier. C'est pas parfait mais ça illustre bien l'idée.

Ici par exemple on voit que l'unicité du `Player#token` est de la responsabilité du `PlayersRepository` mais que la responsabilité de l'unicité de `Table#name` est plutôt du coté du modèle `Table`. Pourtant les deux repositories fonctionnent vraiment de manière similaire en indexant dans un `Hash` les objets à _persister_. La question que je me pose c'est, est-ce que `Table#name` devrait être la responsabilité du `TablesRepository` ?

Un autre truc intéressant avec cette separation, c'est qu'on peut choisir de changer les repositories pour ne plus faire d'in-memory mais pour un autre type de persistance sans changer quoi que ce soit au reste du code.